### PR TITLE
Fix login redirect su WP Multisite

### DIFF
--- a/wp-spid-italia.php
+++ b/wp-spid-italia.php
@@ -272,7 +272,7 @@ add_filter( 'login_message', function( $message ) {
                 wp_set_current_user ( $user->ID );
                 wp_set_auth_cookie  ( $user->ID );
             
-                wp_safe_redirect( apply_filters( 'spid_registration_default_login_redirect', user_admin_url() ) );
+                wp_safe_redirect( apply_filters( 'spid_registration_default_login_redirect', admin_url() ) );
                 exit();
 
             } else {


### PR DESCRIPTION
Su un WP Multisite, la user_admin_url() rimanda al sito principale dello stesso Multisite.
Qui, se il dominio è diverso, l'utente si deve loggare di nuovo, portandolo a credere di aver commesso o essersi imbattuto in un errore.
E' molto più probabile però che lo sviluppatore che implementa questo plugin sul proprio Multisite, voglia che l'utente sia portato alla bacheca admin del blog_id al quale stava cercando di accedere.