### PR TITLE
Update wp-spid-italia.php

### DIFF
--- a/wp-spid-italia.php
+++ b/wp-spid-italia.php
@@ -301,7 +301,7 @@ function spid_handle() {
                 if ( !empty( $users ) ) {
                     $user = reset( $users );
                 } else {
-                    apply_filters( 'spid_registration_filter_new_user', $attributes );
+                    $user = apply_filters( 'spid_registration_filter_new_user', $attributes );
                 }
             }
             if ( !is_wp_error( $user ) && !empty( $user ) ) {


### PR DESCRIPTION
Come proposto da @GolemNet-DEV nel issue #26 mi accodo per proporre la modifica alla riga 304. Ho testato anche io il funzionamento e così si risolve il problema del messaggio di errore "il tuo account non è abilitato su questo sito" nel caso in cui si desideri che l'utente possa eseguire il login con SPID e contestualmente venga creato l'account su WP. Per dettagli rimando al [post di @GolemNet-DEV](https://github.com/WPGov/wp-spid-italia/issues/26#issuecomment-1448249884)