### PR TITLE
Fix errore fatale per funzione spid_errors gia definita

### DIFF
--- a/wp-spid-italia.php
+++ b/wp-spid-italia.php
@@ -210,26 +210,28 @@ function spid_handle() {
             echo '<br><br><pre><small style="color:darkred;">La configurazione SPID ha generato un errore</small></pre>';
         }
 
-        function spid_errors( $errorMsg2 ){
-            $xmlString = isset($_GET['SAMLResponse']) ? gzinflate(base64_decode($_GET['SAMLResponse'])) : base64_decode($_POST['SAMLResponse']);
-            $xmlResp = new \DOMDocument();
-            $xmlResp->loadXML($xmlString);
-            if ( $xmlResp->textContent ) {
-                switch ( $xmlResp->textContent ) {
-                    case stripos( $xmlResp->textContent, 'nr19') !== false:
-                        return '<b>SPID errore 19</b> - Ripetuta sottomissione di credenziali errate';
-                    case stripos( $xmlResp->textContent, 'nr20') !== false:
-                        return '<b>SPID errore 20</b> - Utente privo di credenziali compatibili con il livello richiesto dal fornitore del servizio';
-                    case stripos( $xmlResp->textContent, 'nr21') !== false:
-                        return '<b>SPID errore 21</b> - Timeout';
-                    case stripos( $xmlResp->textContent, 'nr22') !== false:
-                        return '<b>SPID errore 22</b> - Utente nega il consenso all\'invio di dati al SP in caso di sessione vigente';
-                    case stripos( $xmlResp->textContent, 'nr23') !== false:
-                        return '<b>SPID errore 23</b> - Credenziali sospese o revocate';
-                    case stripos( $xmlResp->textContent, 'nr25') !== false:
-                        return '<b>SPID errore 25</b> - Processo di autenticazione annullato dall\'utente';
-                    default: 
-                        return 'Si è verificato un errore durante l\'accesso SPID. Contattare l\'amministratore per maggiori informazioni.';
+        if( !function_exists('spid_errors') ) {
+            function spid_errors( $errorMsg2 ){
+                $xmlString = isset($_GET['SAMLResponse']) ? gzinflate(base64_decode($_GET['SAMLResponse'])) : base64_decode($_POST['SAMLResponse']);
+                $xmlResp = new \DOMDocument();
+                $xmlResp->loadXML($xmlString);
+                if ( $xmlResp->textContent ) {
+                    switch ( $xmlResp->textContent ) {
+                        case stripos( $xmlResp->textContent, 'nr19') !== false:
+                            return '<b>SPID errore 19</b> - Ripetuta sottomissione di credenziali errate';
+                        case stripos( $xmlResp->textContent, 'nr20') !== false:
+                            return '<b>SPID errore 20</b> - Utente privo di credenziali compatibili con il livello richiesto dal fornitore del servizio';
+                        case stripos( $xmlResp->textContent, 'nr21') !== false:
+                            return '<b>SPID errore 21</b> - Timeout';
+                        case stripos( $xmlResp->textContent, 'nr22') !== false:
+                            return '<b>SPID errore 22</b> - Utente nega il consenso all\'invio di dati al SP in caso di sessione vigente';
+                        case stripos( $xmlResp->textContent, 'nr23') !== false:
+                            return '<b>SPID errore 23</b> - Credenziali sospese o revocate';
+                        case stripos( $xmlResp->textContent, 'nr25') !== false:
+                            return '<b>SPID errore 25</b> - Processo di autenticazione annullato dall\'utente';
+                        default:
+                            return 'Si è verificato un errore durante l\'accesso SPID. Contattare l\'amministratore per maggiori informazioni.';
+                    }
                 }
             }
         }


### PR DESCRIPTION
Se la spid_handle e' richiamata piu volte nello stesso flusso di esecuzione e l'IDp ritorna un errore (o viene emessa una eccezione di un altra natura) PHP va in errore fatale per tentativo di dichiarare una funzione gia esistente (spid_errors).
Di conseguenza invece di mostrare un errore di accesso viene mostrata la pagina generica di errore di Wordpress,
il che comporta il non-superamento del collaudo da parte di AGID per check della responce 104-108 e 111.
Con la modifica proposta la gestione errori funziona sempre correttamente e il collaudo e' stato passato.