### PR TITLE
Aggiunta ruolo automatica

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -149,6 +149,24 @@ function spid_menu_func() {
           <input id="sp_contact_phone" name="spid[sp_contact_phone]" type="text" value="<?php echo ( isset( $options['sp_contact_phone']) ? $options['sp_contact_phone'] : '' ); ?>" />
         </td>
       </tr>
+      <tr valign="top">
+        <th scope="row">
+          <label for="sp_add_role">Aggiungi automaticamente un ruolo ai utenti che accedono via SPID</label>
+        </th>
+        <td>
+          <input id="sp_add_role" name="spid[add_role]" type="checkbox" value="1" <?php checked( '1', isset($options['add_role'])  ); ?> />
+        </td>
+      </tr>
+      <tr valign="top">
+        <th scope="row">
+          <label for="sp_role_name">Ruolo da aggiungere</label>
+        </th>
+        <td>
+          <select id="sp_role_name" name="spid[role_name]" type="text">
+            <?php wp_dropdown_roles(isset( $options['role_name']) ? $options['role_name'] : ''); ?>
+          </select>
+        </td>
+      </tr>
     </table>
   <?php
   submit_button();

--- a/wp-spid-italia.php
+++ b/wp-spid-italia.php
@@ -360,6 +360,10 @@ function spid_update_user( $user, $attributes ) {
     
     update_user_meta( $user->ID, 'spid_attributes', $attributes);
     update_user_meta( $user->ID, 'codice_fiscale', $cf);
+    
+    if( spid_option('add_role') ) {
+        $user->add_role( spid_option('role_name') );
+    }
 
     return;
 }


### PR DESCRIPTION
La modifica proposta aggiunge un opzione al plugin che permette di settare un ruolo aggiuntivo all'utente che si logga con SPID.
Utile ad esempio per fare una sezione chiusa sul sito dedicata solo ai utenti SPID.