### PR TITLE
Update settings.php

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -106,7 +106,7 @@ function spid_menu_func() {
           <label for="sp_org_name">sp_org_name</label>
         </th>
         <td>
-          <input id="sp_org_name" name="spid[sp_org_name]" type="text" value="<?php echo ( isset( $options['sp_org_name']) ? $options['sp_org_name'] : '' ); ?>" maxlength="60"/> your organization full name
+          <input id="sp_org_name" name="spid[sp_org_name]" type="text" value="<?php echo ( isset( $options['sp_org_name']) ? $options['sp_org_name'] : '' ); ?>" maxlength="300"/> your organization full name
         </td>
       </tr>
       <tr valign="top">


### PR DESCRIPTION
Increased the sp_org_display_name field limit from 60 to 300 characters. The field must allow to use the entire name of the organization, as shown on IPA. // Aumentato il numero limite di caratteri inseribili nel campo sp_org_display_name da 60 a 300. Il campo deve consentire l'inserimento dell'intera denominazione dell'ente, come indicata su IPA.